### PR TITLE
9pfs: use mapped-file as a security model

### DIFF
--- a/app/src/main/java/app/virtshell/TerminalActivity.java
+++ b/app/src/main/java/app/virtshell/TerminalActivity.java
@@ -497,7 +497,7 @@ public final class TerminalActivity extends Activity implements ServiceConnectio
         // Access to shared storage.
         if (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())) {
             processArgs.addAll(Arrays.asList("-fsdev",
-                "local,security_model=none,id=fsdev0,multidevs=remap,path=/storage/self/primary"));
+                "local,security_model=mapped-file,id=fsdev0,multidevs=remap,path=/storage/self/primary"));
             processArgs.addAll(Arrays.asList("-device",
                 "virtio-9p-pci,fsdev=fsdev0,mount_tag=host_storage,id=virtio-9p-pci0"));
         }


### PR DESCRIPTION
normally Android's internal storage restrictions applies which doesn't support UNIX attributes (symlinks, sockets, device files, permissions)

this 9p security model type attempts to solve this issue by storing all attributes into `.virtfs_metadata` directory which will place all attributes in that directory (would take a little disk space)

using mapped-file model allows to set executable permissions, create symlinks/sockets, device nodes in `/sdcard` but only inside the guest that would be able to treat it as them